### PR TITLE
nlp_challenge에 Citation 추가

### DIFF
--- a/docs/datasets/nlp_challenge.md
+++ b/docs/datasets/nlp_challenge.md
@@ -23,7 +23,15 @@ title: nlp_challenge
 * Citation:
 
   ```text
-  
+  @misc{Naver2018,
+    author = {Naver},
+    title = {NLP Challenge},
+    year = {2018},
+    publisher = {GitHub},
+    journal = {GitHub repository},
+    howpublished = {\url{https://github.com/naver/nlp-challenge}},
+    commit = {a51654472e0da75cd37c6e73ffe583db78e68323}
+  }
   ```
 
 ## Configs

--- a/tfds_korean/nlp_challenge/nlp_challenge.py
+++ b/tfds_korean/nlp_challenge/nlp_challenge.py
@@ -13,7 +13,7 @@ _CITATION = """
   year = {2018},
   publisher = {GitHub},
   journal = {GitHub repository},
-  howpublished = {\url{https://github.com/naver/nlp-challenge}},
+  howpublished = {\\url{https://github.com/naver/nlp-challenge}},
   commit = {a51654472e0da75cd37c6e73ffe583db78e68323}
 }
 """

--- a/tfds_korean/nlp_challenge/nlp_challenge.py
+++ b/tfds_korean/nlp_challenge/nlp_challenge.py
@@ -6,8 +6,16 @@ _DESCRIPTION = """
 네이버, 창원대가 함께하는 NLP Challenge 기술 대회의 NER/SRL 데이터
 """
 
-# TODO(nlp_challenge): BibTeX citation
 _CITATION = """
+@misc{Naver2018,
+  author = {Naver},
+  title = {NLP Challenge},
+  year = {2018},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  howpublished = {\url{https://github.com/naver/nlp-challenge}},
+  commit = {a51654472e0da75cd37c6e73ffe583db78e68323}
+}
 """
 
 VERSION = tfds.core.Version("1.0.0")


### PR DESCRIPTION
* `nlp_challenge`의 소스 코드에 BibTex 형식의 Citation 예시를 추가했습니다.
  * 공식적으로 나온 Citation BibTex가 없기 때문에, Github Repo를 참조하는 일반적인 예시를 사용했습니다.